### PR TITLE
Swap Request/Response -> AWSPreparedRequest/AioAWSResponse types in endpoint.pyi

### DIFF
--- a/aiobotocore-stubs/endpoint.pyi
+++ b/aiobotocore-stubs/endpoint.pyi
@@ -6,25 +6,26 @@ Copyright 2025 Vlad Emelianov
 
 from typing import Any, Mapping
 
+from aiobotocore.awsrequest import AioAWSResponse
 from aiobotocore.httpsession import AIOHTTPSession as AIOHTTPSession
 from aiobotocore.response import StreamingBody as StreamingBody
+from botocore.awsrequest import AWSPreparedRequest
 from botocore.endpoint import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT
 from botocore.endpoint import MAX_POOL_CONNECTIONS as MAX_POOL_CONNECTIONS
 from botocore.endpoint import Endpoint, EndpointCreator
 from botocore.model import OperationModel, ServiceModel
-from requests.models import Request, Response
 
 DEFAULT_HTTP_SESSION_CLS: type[AIOHTTPSession] = ...
 
 async def convert_to_response_dict(
-    http_response: Response, operation_model: OperationModel
+    http_response: AioAWSResponse, operation_model: OperationModel
 ) -> dict[str, Any]: ...
 
 class AioEndpoint(Endpoint):
     async def close(self) -> None: ...  # type: ignore[override]
     async def create_request(
         self, params: Mapping[str, Any], operation_model: OperationModel | None = ...
-    ) -> Request: ...
+    ) -> AWSPreparedRequest: ...
 
 class AioEndpointCreator(EndpointCreator):
     def create_endpoint(  # type: ignore[override]


### PR DESCRIPTION
This aligns the annotations of the `convert_to_response_dict` to the "reality" of the underlying code:

- the `convert_to_response_dict` function receives `AioAWSResponse` objects:
  - it's called with the result of `AioEndpoint._send`: https://github.com/aio-libs/aiobotocore/blob/7c41f8ad0cf70bf8a64b5196037f7445f43568e6/aiobotocore/endpoint.py#L181-L192
  - that calls/returns `self.http_session.send(...)`: https://github.com/aio-libs/aiobotocore/blob/7c41f8ad0cf70bf8a64b5196037f7445f43568e6/aiobotocore/endpoint.py#L293-L294
  - `http_session` is, by default, a `AIOHTTPSession`: https://github.com/aio-libs/aiobotocore/blob/7c41f8ad0cf70bf8a64b5196037f7445f43568e6/aiobotocore/endpoint.py#L22
  - `AIOHTTPSession.send` returns a `AioAWSResponse`: https://github.com/aio-libs/aiobotocore/blob/7c41f8ad0cf70bf8a64b5196037f7445f43568e6/aiobotocore/httpsession.py#L232-L242
- the `create_request` function returns `AWSPreparedRequest`:
  - `create_request` returns the result of `self.prepare_request`: https://github.com/aio-libs/aiobotocore/blob/7c41f8ad0cf70bf8a64b5196037f7445f43568e6/aiobotocore/endpoint.py#L89-L90
  - that's `botocore.Endpoint.prepare_request` from the superclass, which returns `request.prepare()`: https://github.com/boto/botocore/blob/51f1d36c1809357eb6322fdc699d00efe74c0218/botocore/endpoint.py#L148
  - `AWSRequest.prepare` is documented to return `AWSPreparedRequest`: https://github.com/boto/botocore/blob/51f1d36c1809357eb6322fdc699d00efe74c0218/botocore/awsrequest.py#L480

---

Thanks for maintaining these stubs! I'm not sure if this PR should be here or against https://github.com/youtype/mypy_boto3_builder!