### PR TITLE
Use typing.Protocol for AioConfig's http_session_cls

### DIFF
--- a/aiobotocore-stubs/config.pyi
+++ b/aiobotocore-stubs/config.pyi
@@ -4,9 +4,11 @@ Type annotations for aiobotocore.config module.
 Copyright 2025 Vlad Emelianov
 """
 
-from typing import Any, TypeVar
+from types import TracebackType
+from typing import Any, Protocol, TypeVar
 
-from aiobotocore.httpsession import AIOHTTPSession
+from aiobotocore.awsrequest import AioAWSResponse
+from botocore.awsrequest import AWSPreparedRequest
 from botocore.config import Config
 
 _Config = TypeVar("_Config", bound=Config)
@@ -14,8 +16,35 @@ _Config = TypeVar("_Config", bound=Config)
 DEFAULT_KEEPALIVE_TIMEOUT: int = ...
 TIMEOUT_ARGS: frozenset[str] = ...
 
+_R = TypeVar("_R")
+
+class _HTTPSessionProtocol(Protocol):
+    def __init__(
+        self,
+        verify: bool = ...,
+        proxies: dict[str, str] | None = ...,
+        timeout: float | None = ...,
+        max_pool_connections: int = ...,
+        socket_options: list[Any] | None = ...,
+        client_cert: str | tuple[str, str] | None = ...,
+        proxies_config: dict[str, str] | None = ...,
+        connector_args: dict[str, Any] | None = ...,
+    ) -> None: ...
+    async def __aenter__(self: _R) -> _R: ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+    async def close(self) -> None: ...
+    async def send(self, request: AWSPreparedRequest) -> AioAWSResponse: ...
+
 class AioConfig(Config):
     def __init__(
-        self, connector_args: Any = ..., http_session_cls: type[AIOHTTPSession] = ..., **kwargs: Any
+        self,
+        connector_args: Any = ...,
+        http_session_cls: type[_HTTPSessionProtocol] = ...,
+        **kwargs: Any,
     ) -> None: ...
     def merge(self: _Config, other_config: _Config) -> _Config: ...

--- a/aiobotocore-stubs/httpsession.pyi
+++ b/aiobotocore-stubs/httpsession.pyi
@@ -7,8 +7,9 @@ Copyright 2025 Vlad Emelianov
 from types import TracebackType
 from typing import Any, TypeVar
 
+from aiobotocore.awsrequest import AioAWSResponse
+from botocore.awsrequest import AWSPreparedRequest
 from botocore.endpoint import MAX_POOL_CONNECTIONS as MAX_POOL_CONNECTIONS
-from requests.models import Request, Response
 
 _R = TypeVar("_R")
 
@@ -32,4 +33,4 @@ class AIOHTTPSession:
         tb: TracebackType | None,
     ) -> None: ...
     async def close(self) -> None: ...
-    async def send(self, request: Request) -> Response: ...
+    async def send(self, request: AWSPreparedRequest) -> AioAWSResponse: ...

--- a/test.py
+++ b/test.py
@@ -1,5 +1,10 @@
+from aiobotocore.config import AioConfig
+from aiobotocore.httpsession import AIOHTTPSession
+from aiobotocore.httpxsession import HttpxSession
 from aiobotocore.utils import AioIMDSFetcher
 
 fetcher = AioIMDSFetcher(env="dev")
 fetcher = AioIMDSFetcher(env=None)
 fetcher = AioIMDSFetcher(env=123)
+config = AioConfig(http_session_cls=AIOHTTPSession)
+config = AioConfig(http_session_cls=HttpxSession)


### PR DESCRIPTION
`AioConfig` accepts any type which implements an interface compatible with `AIOHTTPSession` for the `http_session_cls` argument, but the static stubs permit only the concrete class.

This specifically causes `aiobotocore.httpxsession.HttpxSession`, added in aiobotocore 2.23.0, to be prohibited.

Add an `_HTTPSessionProtocol` protocol, using narrowed method signatures from `AIOHTTPSession`, and change `type[AIOHTTPSession]` to `type[_HTTPSessionProtocol]` in `AioConfig.__init__` constructor signature.

Update `AIOHTTPSession` stub's `send` method with the correct modern type signature.

Test output: (the one error is pre-existing)

```
$ uv run mypy ./test.py
test.py:8: error: Argument "env" to "AioIMDSFetcher" has incompatible type "int"; expected "Optional[str]"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```